### PR TITLE
add CacheConstants and Jackson configuration for JSON serialization

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -76,6 +76,13 @@
             <artifactId>spring-kafka-test</artifactId>
             <scope>test</scope>
         </dependency>
+
+<!--        Jackson-->
+        <dependency>
+            <groupId>com.fasterxml.jackson.datatype</groupId>
+            <artifactId>jackson-datatype-jsr310</artifactId>
+        </dependency>
+
     </dependencies>
 
     <build>

--- a/src/main/java/vn/vinaacademy/common/config/JacksonConfig.java
+++ b/src/main/java/vn/vinaacademy/common/config/JacksonConfig.java
@@ -1,0 +1,61 @@
+package vn.vinaacademy.common.config;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.databind.*;
+import com.fasterxml.jackson.databind.module.SimpleModule;
+import com.fasterxml.jackson.databind.ser.std.ToStringSerializer;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+
+@Configuration
+public class JacksonConfig {
+
+    @Bean
+    public ObjectMapper objectMapper() {
+        ObjectMapper mapper = new ObjectMapper();
+
+        // 👇 Loại bỏ null field khỏi JSON
+        mapper.setSerializationInclusion(JsonInclude.Include.NON_NULL);
+
+        // 👇 Tắt timestamp cho date
+        mapper.disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS);
+
+        // 👇 Xử lý các field không nhận dạng được
+        mapper.disable(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES);
+
+        // 👇 Tự động escape HTML (optional tùy dự án)
+//        mapper.getFactory().configure(JsonGenerator.Feature.ESCAPE_NON_ASCII, true);
+
+        // 👇 DateTime formatter ISO hoặc custom
+        JavaTimeModule timeModule = new JavaTimeModule();
+        timeModule.addSerializer(LocalDateTime.class,
+                new JsonSerializer<>() {
+                    private final DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss");
+
+                    @Override
+                    public void serialize(LocalDateTime value, JsonGenerator gen, SerializerProvider serializers) throws java.io.IOException {
+                        gen.writeString(value.format(formatter));
+                    }
+                });
+
+        // 👇 Optional: Serialize BigDecimal thành String để tránh mất độ chính xác JSON
+        SimpleModule bigDecimalModule = new SimpleModule();
+        bigDecimalModule.addSerializer(BigDecimal.class, ToStringSerializer.instance);
+
+        // 👇 Optional: Serialize Enum rõ ràng (theo name thay vì ordinal)
+        mapper.enable(SerializationFeature.WRITE_ENUMS_USING_TO_STRING);
+        mapper.enable(DeserializationFeature.READ_ENUMS_USING_TO_STRING);
+
+        // Đăng ký các modules
+        mapper.registerModule(timeModule);
+        mapper.registerModule(bigDecimalModule);
+
+        return mapper;
+    }
+}

--- a/src/main/java/vn/vinaacademy/common/constant/CacheConstants.java
+++ b/src/main/java/vn/vinaacademy/common/constant/CacheConstants.java
@@ -1,0 +1,8 @@
+package vn.vinaacademy.common.constant;
+
+public class CacheConstants {
+    public static final String CATEGORY = "category";
+    public static final String CATEGORIES = "categories";
+    public static final String SHORT_TERM = "shortTerm";
+    public static final String LONG_TERM = "longTerm";
+}


### PR DESCRIPTION
This pull request introduces improvements to JSON serialization and caching by adding a custom Jackson configuration and defining constants for cache keys. The most important changes include adding the Jackson dependency to the `pom.xml`, creating a `JacksonConfig` class to customize object mapping, and defining cache-related constants in `CacheConstants`.

### JSON Serialization Improvements:
* [`pom.xml`](diffhunk://#diff-9c5fb3d1b7e3b0f54bc5c4182965c4fe1f9023d449017cece3005d3f90e8e4d8R79-R85): Added the `jackson-datatype-jsr310` dependency to support Java 8 time types in JSON serialization.
* `src/main/java/vn/vinaacademy/common/config/JacksonConfig.java`: Created a new `JacksonConfig` class to configure the `ObjectMapper`. This includes:
  - Excluding null fields from JSON.
  - Disabling timestamps for dates.
  - Handling unknown properties gracefully.
  - Customizing `LocalDateTime` serialization with a specific format.
  - Serializing `BigDecimal` as strings to prevent precision loss.
  - Enabling clear enum serialization using names instead of ordinals.

### Caching Enhancements:
* [`src/main/java/vn/vinaacademy/common/constant/CacheConstants.java`](diffhunk://#diff-f84866f974916fae9a497a98fc392c8cdcb57703c7b15b01217e2befb3b797abR1-R8): Added a new `CacheConstants` class to define constants for cache keys, such as `CATEGORY`, `CATEGORIES`, `SHORT_TERM`, and `LONG_TERM`.

## Summary by Sourcery

Configure Jackson’s ObjectMapper with custom modules and settings for improved JSON serialization and centralize cache key constants

New Features:
- Introduce JacksonConfig to customize JSON serialization globally
- Add CacheConstants to centralize application cache key names

Enhancements:
- Enable Java 8 date/time support with custom LocalDateTime formatting
- Serialize BigDecimal as strings and enums using names
- Exclude null fields and ignore unknown properties in JSON output

Build:
- Add jackson-datatype-jsr310 dependency for Java time serialization